### PR TITLE
Enemy spawn Area2D

### DIFF
--- a/scenes/enemy/Areas/SpawnArea2D.tscn
+++ b/scenes/enemy/Areas/SpawnArea2D.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=3 format=3 uid="uid://d0ojokxokewku"]
+
+[ext_resource type="Script" path="res://scripts/enemy/Areas/spawnarea.gd" id="1_q8p6j"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_b2ux1"]
+radius = 150.0
+
+[node name="SpawnArea2D" type="Area2D"]
+script = ExtResource("1_q8p6j")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("CircleShape2D_b2ux1")

--- a/scenes/enemy/Areas/SpawnArea2D.tscn
+++ b/scenes/enemy/Areas/SpawnArea2D.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" path="res://scripts/enemy/Areas/spawnarea.gd" id="1_q8p6j"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_b2ux1"]
+resource_local_to_scene = true
 radius = 150.0
 
 [node name="SpawnArea2D" type="Area2D"]

--- a/scenes/enemy/Areas/SpawnArea2D.tscn
+++ b/scenes/enemy/Areas/SpawnArea2D.tscn
@@ -7,6 +7,7 @@ radius = 150.0
 
 [node name="SpawnArea2D" type="Area2D"]
 script = ExtResource("1_q8p6j")
+radius = 150.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_b2ux1")

--- a/scripts/enemy/Areas/spawnarea.gd
+++ b/scripts/enemy/Areas/spawnarea.gd
@@ -1,0 +1,34 @@
+extends Area2D
+
+# Spawns enemy within radius
+
+# Make sure this is not 0
+@export var allowed_enemies: Array[PackedScene] = []
+
+@onready var radius = $CollisionShape2D.shape.radius
+
+func _ready() -> void:
+	assert(len(allowed_enemies) > 0) 
+
+func spawn_single():
+	
+	var e = allowed_enemies.pick_random().instantiate()
+	e.global_position = global_position + radius * get_random_point()
+	
+	# Add child to root node
+	get_tree().root.add_child(e)
+
+
+func spawn_batch(amount: int):
+	
+	pass
+
+func get_random_point():
+	var x = sin(randf_range(-radius, radius))
+	var y = cos(randf_range(-radius, radius))
+	return Vector2(x , y)
+
+# Testing purposes
+func _input(event: InputEvent) -> void:
+	if Input.is_action_just_pressed("roll"):
+		spawn_single()

--- a/scripts/enemy/Areas/spawnarea.gd
+++ b/scripts/enemy/Areas/spawnarea.gd
@@ -16,9 +16,9 @@ extends Area2D
 
 func _ready() -> void:
 	#assert(len(allowed_enemies) > 0)
-	#assert(allowed_enemies.size() > 0)
-	print(allowed_enemies.size())
-	print(radius)
+	assert(allowed_enemies.size() > 0)
+	#print(allowed_enemies.size())
+	#print(radius)
 	
 	collisionshape.set("radius", radius)
 

--- a/scripts/enemy/Areas/spawnarea.gd
+++ b/scripts/enemy/Areas/spawnarea.gd
@@ -5,30 +5,38 @@ extends Area2D
 # Make sure this is not 0
 @export var allowed_enemies: Array[PackedScene] = []
 
-@onready var radius = $CollisionShape2D.shape.radius
+# Expose CollisionShape radius to scene root in editor
+@onready var collisionshape: CollisionShape2D = $CollisionShape2D
+@export var radius: float:
+	set(x):
+		radius = x
+		if collisionshape:
+			collisionshape.radius = x
+
 
 func _ready() -> void:
-	assert(len(allowed_enemies) > 0) 
-
-func spawn_single():
+	#assert(len(allowed_enemies) > 0)
+	#assert(allowed_enemies.size() > 0)
+	print(allowed_enemies.size())
+	print(radius)
 	
+	collisionshape.set("radius", radius)
+
+# Make sure 
+func spawn_single():
 	var e = allowed_enemies.pick_random().instantiate()
-	e.global_position = global_position + radius * get_random_point()
+	e.global_position = global_position + collisionshape.radius * get_random_point()
 	
 	# Add child to root node
 	get_tree().root.add_child(e)
 
 
 func spawn_batch(amount: int):
-	
-	pass
+	for i in range(amount):
+		spawn_single()
 
 func get_random_point():
-	var x = sin(randf_range(-radius, radius))
-	var y = cos(randf_range(-radius, radius))
+	var r = collisionshape.radius
+	var x = sin(randf_range(-r, r))
+	var y = cos(randf_range(-r, r))
 	return Vector2(x , y)
-
-# Testing purposes
-func _input(event: InputEvent) -> void:
-	if Input.is_action_just_pressed("roll"):
-		spawn_single()

--- a/scripts/enemy/Areas/spawnarea.gd
+++ b/scripts/enemy/Areas/spawnarea.gd
@@ -1,6 +1,9 @@
 extends Area2D
 
 # Spawns enemy within radius
+# The CollisionShape2D is local to scene, so if there are multiple of this node,
+# the radius or even shape can be changed dynamically in the editor. You just need 
+# to right click this scene and select "Editable Children".
 
 # Make sure this is not 0
 @export var allowed_enemies: Array[PackedScene] = []


### PR DESCRIPTION
- Adds Area2D that spawns Enemies in its CollisionShape2D
 - Can spawn a single enemy or spawn multiple, in a random point in the CollisionShape2D shape.
- Spawned enemies configured in `allowed_enemies` in Inspector
 - Spawner will pick a random enemy if there is more than 1 in the array.
- CollisionShape2D shape and size is configurable, as it is Local to Scene.

- No trigger added to the spawner (eg a Timer to spawn enemies on a clock)