### PR TITLE
Disable web deploys to gh-pages due to export size

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,8 @@ jobs:
           sed -i '3 i <script src="coi-serviceworker.js"></script>' build/web/index.html
 
       - name: 🚀 Deploy to `gh-pages` branch # Push - deploy to main directory
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        if: false  # Disable this for now, size is too large for gh page deploys
+        # if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -88,7 +89,8 @@ jobs:
           commit_message: "Deploy main branch push to main directory"
 
       - name: 🚀 Deploy to `gh-pages` branch # PR - deploy to subdirectory
-        if: github.event_name == 'pull_request'
+        if: false  # Disable this for now, size is too large for gh page deploys
+        # if: github.event_name == 'pull_request'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -274,7 +276,8 @@ jobs:
         id: set-message
         run: |
           if [[ "${{ needs.Builds.result }}" == "success" ]]; then
-            echo "message=🌐 [Web Preview](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ github.event.pull_request.number }}/)" >> $GITHUB_OUTPUT
+            # echo "message=🌐 [Web Preview](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ github.event.pull_request.number }}/)" >> $GITHUB_OUTPUT
+            echo "message=🌐 Deployment succeeded for this PR. Preview has been disabled." >> $GITHUB_OUTPUT
           else
             echo "message=❌ Deployment failed for this PR." >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
Unfortunately we have exceeded the github file size of 100MB again, at 115MB with all the newly added assets.

It'll likely take too long to compress the file sizes down, not to mention that there will likely be more assets added soon.

This PR disables the web deploy but everything else should still run, including making the release and pushing to steam.